### PR TITLE
Avoid usage of babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     ],
     "plugins": [
         "add-module-exports",
+        "transform-runtime",
         "transform-class-properties",
         "transform-function-bind",
         "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "url": "https://github.com/zeroturnaround/sql-formatter.git"
   },
   "dependencies": {
-    "babel-polyfill": "^6.9.1",
     "lodash": "^4.14.0"
   },
   "devDependencies": {
@@ -51,6 +50,7 @@
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
     "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "check-es3-syntax-cli": "^0.1.1",
     "cross-env": "^1.0.7",

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -25,7 +25,7 @@ export default class Indentation {
      * @return {String}
      */
     getIndent() {
-        return this.indent.repeat(this.indentTypes.length);
+        return _.repeat(this.indent, this.indentTypes.length);
     }
 
     /**

--- a/src/sqlFormatter.js
+++ b/src/sqlFormatter.js
@@ -1,4 +1,3 @@
-import "babel-polyfill";
 import N1qlFormatter from "./languages/N1qlFormatter";
 import StandardSqlFormatter from "./languages/StandardSqlFormatter";
 


### PR DESCRIPTION
See https://babeljs.io/docs/usage/polyfill/

> If you are looking for something that won't modify globals to be used in a tool/library, checkout the transform-runtime plugin. This means you won't be able to use the instance methods mentioned above like Array.includes.