### PR TITLE
Fix multiple parens formatting

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -111,9 +111,9 @@ export default class Formatter {
 
     // Opening parentheses increase the block indent level and start a new line
     formatOpeningParentheses(tokens, index, query) {
-        // Take out the preceding space unless there was whitespace there in the original query
+        // Take out the preceding space unless there was whitespace there in the original query or another opening parens
         const previousToken = tokens[index - 1];
-        if (previousToken && previousToken.type !== sqlTokenTypes.WHITESPACE) {
+        if (previousToken && previousToken.type !== sqlTokenTypes.WHITESPACE && previousToken.type !== sqlTokenTypes.OPEN_PAREN) {
             query = _.trimEnd(query);
         }
         query += tokens[index].value;

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -355,6 +355,22 @@ export default function behavesLikeSqlFormatter(language) {
         );
     });
 
+    it("formats long double parenthized queries to multiple lines", function() {
+        const result = format("((foo = '0123456789-0123456789-0123456789-0123456789'))");
+        expect(result).toBe(
+            "(\n" +
+            "  (\n" +
+            "    foo = '0123456789-0123456789-0123456789-0123456789'\n" +
+            "  )\n" +
+            ")\n"
+        );
+    });
+
+    it("formats short double parenthized queries to one line", function() {
+        const result = format("((foo = 'bar'))");
+        expect(result).toBe("((foo = 'bar'))\n");
+    });
+
     it("formats single-char operators", function() {
         expect(format("foo = bar")).toBe("foo = bar\n");
         expect(format("foo < bar")).toBe("foo < bar\n");


### PR DESCRIPTION
Make sure that query is not trimmed before adding another opening parentheses

This can happen when using double parens.