### PR TITLE
Adding Postgres specific operators

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -19,7 +19,7 @@ export default class Tokenizer {
         this.LINE_COMMENT_REGEX = /^((?:#|--).*?(?:\n|$))/;
         this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/;
         this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/;
-        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||.)/;
+        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|.)/;
 
         this.RESERVED_TOPLEVEL_REGEX = this.createReservedWordRegex(cfg.reservedToplevelWords);
         this.RESERVED_NEWLINE_REGEX = this.createReservedWordRegex(cfg.reservedNewlineWords);

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -432,4 +432,10 @@ export default function behavesLikeSqlFormatter(language) {
         expect(format("'foo \\' JOIN bar'")).toBe("'foo \\' JOIN bar'\n");
         expect(format("`foo `` JOIN bar`")).toBe("`foo `` JOIN bar`\n");
     });
+
+    it("formats postgres specific operators", function() {
+        expect(format("column::int")).toBe("column :: int\n");
+        expect(format("v->2")).toBe("v -> 2\n");
+        expect(format("v->>2")).toBe( "v ->> 2\n");
+    });
 }


### PR DESCRIPTION
Postgresql has several specific operators:
'::' - cast operator
'->' - get JSON element
'->>' - get JSON element as text
This commit adds them to the list of standard operators in order to not
break them when formatting.

https://github.com/zeroturnaround/sql-formatter/issues/23