### PR TITLE
Add support tree-shaking for lodash by using implicit import

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import trimEnd from "lodash/trimEnd";
 import tokenTypes from "./tokenTypes";
 import Indentation from "./Indentation";
 import InlineBlock from "./InlineBlock";
@@ -120,7 +120,7 @@ export default class Formatter {
         // Take out the preceding space unless there was whitespace there in the original query or another opening parens
         const previousToken = tokens[index - 1];
         if (previousToken && previousToken.type !== tokenTypes.WHITESPACE && previousToken.type !== tokenTypes.OPEN_PAREN) {
-            query = _.trimEnd(query);
+            query = trimEnd(query);
         }
         query += tokens[index].value;
 
@@ -151,7 +151,7 @@ export default class Formatter {
 
     // Commas start a new line (unless within inline parentheses or SQL "LIMIT" clause)
     formatComma(token, query) {
-        query = _.trimEnd(query) + token.value + " ";
+        query = trimEnd(query) + token.value + " ";
 
         if (this.inlineBlock.isActive()) {
             return query;
@@ -165,11 +165,11 @@ export default class Formatter {
     }
 
     formatWithSpaceAfter(token, query) {
-        return _.trimEnd(query) + token.value + " ";
+        return trimEnd(query) + token.value + " ";
     }
 
     formatWithoutSpaces(token, query) {
-        return _.trimEnd(query) + token.value;
+        return trimEnd(query) + token.value;
     }
 
     formatWithSpaces(token, query) {
@@ -177,6 +177,6 @@ export default class Formatter {
     }
 
     addNewline(query) {
-        return _.trimEnd(query) + "\n" + this.indentation.getIndent();
+        return trimEnd(query) + "\n" + this.indentation.getIndent();
     }
 }

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -1,4 +1,5 @@
-import _ from "lodash";
+import repeat from "lodash/repeat";
+import last from "lodash/last";
 
 const INDENT_TYPE_TOP_LEVEL = "top-level";
 const INDENT_TYPE_BLOCK_LEVEL = "block-level";
@@ -25,7 +26,7 @@ export default class Indentation {
      * @return {String}
      */
     getIndent() {
-        return _.repeat(this.indent, this.indentTypes.length);
+        return repeat(this.indent, this.indentTypes.length);
     }
 
     /**
@@ -47,7 +48,7 @@ export default class Indentation {
      * Does nothing when the previous indent is not top-level.
      */
     decreaseTopLevel() {
-        if (_.last(this.indentTypes) === INDENT_TYPE_TOP_LEVEL) {
+        if (last(this.indentTypes) === INDENT_TYPE_TOP_LEVEL) {
             this.indentTypes.pop();
         }
     }

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -1,4 +1,5 @@
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
+import escapeRegExp from "lodash/escapeRegExp";
 import tokenTypes from "./tokenTypes";
 
 export default class Tokenizer {
@@ -42,7 +43,7 @@ export default class Tokenizer {
     }
 
     createLineCommentRegex(lineCommentTypes) {
-        return new RegExp(`^((?:${lineCommentTypes.map(c => _.escapeRegExp(c)).join("|")}).*?(?:\n|$))`);
+        return new RegExp(`^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join("|")}).*?(?:\n|$))`);
     }
 
     createReservedWordRegex(reservedWords) {
@@ -80,15 +81,15 @@ export default class Tokenizer {
 
     createParenRegex(parens) {
         return new RegExp(
-            "^(" + parens.map(p => _.escapeRegExp(p)).join("|") + ")"
+            "^(" + parens.map(p => escapeRegExp(p)).join("|") + ")"
         );
     }
 
     createPlaceholderRegex(types, pattern) {
-        if (_.isEmpty(types)) {
+        if (isEmpty(types)) {
             return false;
         }
-        const typesRegex = types.map(_.escapeRegExp).join("|");
+        const typesRegex = types.map(escapeRegExp).join("|");
 
         return new RegExp(`^((?:${typesRegex})(?:${pattern}))`);
     }
@@ -222,7 +223,7 @@ export default class Tokenizer {
     }
 
     getEscapedPlaceholderKey({key, quoteChar}) {
-        return key.replace(new RegExp(_.escapeRegExp("\\") + quoteChar, "g"), quoteChar);
+        return key.replace(new RegExp(escapeRegExp("\\") + quoteChar, "g"), quoteChar);
     }
 
     // Decimal, binary, or hex numbers


### PR DESCRIPTION
Improve bundle size

Old:

    sql-formatter.js  607 kB
    sql-formatter.min.js  96.6 kB

New:

    sql-formatter.js  102 kB
    sql-formatter.min.js  35.3 kB