### PR TITLE
Adding more Postgres specific operators

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -19,7 +19,7 @@ export default class Tokenizer {
     constructor(cfg) {
         this.WHITESPACE_REGEX = /^(\s+)/;
         this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/;
-        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|.)/;
+        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|!?~+\*?|.)/;
 
         this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/;
         this.LINE_COMMENT_REGEX = this.createLineCommentRegex(cfg.lineCommentTypes);

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -19,7 +19,7 @@ export default class Tokenizer {
     constructor(cfg) {
         this.WHITESPACE_REGEX = /^(\s+)/;
         this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/;
-        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|!?~+\*?|.)/;
+        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|!?~~?\*?|.)/;
 
         this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/;
         this.LINE_COMMENT_REGEX = this.createLineCommentRegex(cfg.lineCommentTypes);

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -437,5 +437,11 @@ export default function behavesLikeSqlFormatter(language) {
         expect(format("column::int")).toBe("column :: int");
         expect(format("v->2")).toBe("v -> 2");
         expect(format("v->>2")).toBe( "v ->> 2");
+        expect(format("foo ~~ 'hello'")).toBe("foo ~~ 'hello'");
+        expect(format("foo !~ 'hello'")).toBe("foo !~ 'hello'");
+        expect(format("foo ~* 'hello'")).toBe("foo ~* 'hello'");
+        expect(format("foo !~~ 'hello'")).toBe("foo !~~ 'hello'");
+        expect(format("foo !~* 'hello'")).toBe("foo !~* 'hello'");
+        expect(format("foo !~~* 'hello'")).toBe("foo !~~* 'hello'");
     });
 }

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -440,6 +440,7 @@ export default function behavesLikeSqlFormatter(language) {
         expect(format("foo ~~ 'hello'")).toBe("foo ~~ 'hello'");
         expect(format("foo !~ 'hello'")).toBe("foo !~ 'hello'");
         expect(format("foo ~* 'hello'")).toBe("foo ~* 'hello'");
+        expect(format("foo ~~* 'hello'")).toBe("foo ~~* 'hello'");
         expect(format("foo !~~ 'hello'")).toBe("foo !~~ 'hello'");
         expect(format("foo !~* 'hello'")).toBe("foo !~* 'hello'");
         expect(format("foo !~~* 'hello'")).toBe("foo !~~* 'hello'");


### PR DESCRIPTION
Postgresql has several specific operators(addition to [#24](https://github.com/zeroturnaround/sql-formatter/pull/24))
more info can be found: https://www.postgresql.org/docs/8.4/static/functions-matching.html
`~~` - represent LIKE
`~~*` - represent ILIKE
`!~~` - represent NOT LIKE
`!~~*` represent NOT ILIKE
Regular Expression Match Operators:
`~*`,
`!~`,
`!~*`,
This commit adds them to the list of standard operators in order to not
break them when formatting.