### PR TITLE
No transpilation for nodejs usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
-    "extends": "zt/base",
+    "parserOptions": {
+        "ecmaVersion": 7,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "modules": true
+        }
+    },
     "env": {
         "jest": true
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: node
 
 install:
   - npm install
-  - npm install coveralls
+  - npm install coveralls rollup
 script:
   - npm run check
   - npm run build

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require = require("esm")(module/*, options*/)
+module.exports = require("src/sqlFormatter.js");

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "lint": "eslint .",
-    "test": "jest",
+    "test": "mocha -r esm",
     "test:watch": "npm run test -- --watch",
     "check": "npm run lint && npm run test",
     "build:webpack": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
@@ -32,7 +32,7 @@
     "build:umd": "cross-env NODE_ENV=development webpack src/sqlFormatter.js dist/sql-formatter.js",
     "build:umd:min": "cross-env NODE_ENV=production webpack src/sqlFormatter.js dist/sql-formatter.min.js",
     "build": "rollup -c rollup.js",
-    "prepublish": "npm run clean && npm run check && npm run build"
+    "prepublishOnly": "npm run clean && npm run check && npm run build"
   },
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "eslint": "^3.7.1",
-    "jest": "^17.0.2",
+    "mocha": "^3.5.3",
     "rimraf": "^2.3.4",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-node-resolve": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.3.1",
   "description": "Formats whitespaces in a SQL query to make it more readable",
   "license": "MIT",
-  "main": "lib/sqlFormatter.js",
+  "main": "index.js",
+  "module": "src/sqlFormatter.js",
   "keywords": [
     "sql",
     "formatter",
@@ -26,10 +27,11 @@
     "test": "jest",
     "test:watch": "npm run test -- --watch",
     "check": "npm run lint && npm run test",
-    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build:webpack": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "build:commonjs": "babel src --out-dir lib",
     "build:umd": "cross-env NODE_ENV=development webpack src/sqlFormatter.js dist/sql-formatter.js",
     "build:umd:min": "cross-env NODE_ENV=production webpack src/sqlFormatter.js dist/sql-formatter.min.js",
+    "build": "rollup -c rollup.js",
     "prepublish": "npm run clean && npm run check && npm run build"
   },
   "repository": {
@@ -40,10 +42,18 @@
     "url": "https://github.com/zeroturnaround/sql-formatter/issues"
   },
   "dependencies": {
-    "babel-runtime": "^6.18.0",
-    "lodash": "^4.16.0"
+    "esm": "^3.0.77",
+    "lodash-es": "^4.17.10"
   },
   "devDependencies": {
+    "eslint": "^3.7.1",
+    "jest": "^17.0.2",
+    "rimraf": "^2.3.4",
+    "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-uglify": "^4.0.0"
+  },
+  "devDependenciesOld": {
     "babel-cli": "^6.14.0",
     "babel-core": "^6.11.4",
     "babel-eslint": "^7.1.0",

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,58 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+
+import buble from 'rollup-plugin-buble';
+
+import { uglify } from 'rollup-plugin-uglify';
+
+// plugins should not be shared
+// https://github.com/rollup/rollup/issues/703#issuecomment-306246339
+function plugins (forProduction) {
+	return [
+		buble (),
+		nodeResolve({ jsnext: true, module: true })
+	];
+}
+
+function output () {
+	return {
+		format: 'iife',
+		sourcemap: true,
+		globals: {
+		}
+	};
+}
+
+function external () {
+	return [
+	];
+}
+
+export default [{
+	// regular build
+	input: 'src/sqlFormatter.js',
+
+	plugins: plugins(),
+	output: Object.assign ({
+		file: 'dist/sql-formatter.js',
+		name: 'sqlFormatter',
+	}, output()),
+	external: external()
+}, {
+	// minified build
+	input: 'src/sqlFormatter.js',
+
+	plugins: plugins().concat(uglify({
+		compress: {
+			pure_getters: true,
+			unsafe: true,
+			unsafe_comps: true,
+			warnings: false
+		}
+	})),
+	output: Object.assign ({
+		file: 'dist/sql-formatter.min.js',
+		name: 'sqlFormatter',
+	}, output()),
+	external: external()
+
+}]

--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -1,4 +1,4 @@
-import trimEnd from "lodash/trimEnd";
+import trimEnd from "lodash-es/trimEnd";
 import tokenTypes from "./tokenTypes";
 import Indentation from "./Indentation";
 import InlineBlock from "./InlineBlock";

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -1,5 +1,5 @@
-import repeat from "lodash/repeat";
-import last from "lodash/last";
+import repeat from "lodash-es/repeat";
+import last from "lodash-es/last";
 
 const INDENT_TYPE_TOP_LEVEL = "top-level";
 const INDENT_TYPE_BLOCK_LEVEL = "block-level";

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -1,5 +1,5 @@
-import isEmpty from "lodash/isEmpty";
-import escapeRegExp from "lodash/escapeRegExp";
+import isEmpty from "lodash-es/isEmpty";
+import escapeRegExp from "lodash-es/escapeRegExp";
 import tokenTypes from "./tokenTypes";
 
 export default class Tokenizer {

--- a/test/Db2FormatterTest.js
+++ b/test/Db2FormatterTest.js
@@ -1,14 +1,16 @@
 import sqlFormatter from "./../src/sqlFormatter";
 import behavesLikeSqlFormatter from "./behavesLikeSqlFormatter";
 
+import assert from 'assert';
+
 describe("Db2Formatter", function() {
     behavesLikeSqlFormatter("db2");
 
     it("formats FETCH FIRST like LIMIT", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;",
             {language: "db2"}
-        )).toBe(
+        ),
             "SELECT\n" +
             "  col1\n" +
             "FROM\n" +
@@ -27,7 +29,7 @@ describe("Db2Formatter", function() {
             "MyTable;\n",
             {language: "db2"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  col\n" +
             "FROM\n" +
@@ -41,7 +43,7 @@ describe("Db2Formatter", function() {
             "SELECT col#1, @col2 FROM tbl\n",
             {language: "db2"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  col#1,\n" +
             "  @col2\n" +
@@ -51,7 +53,7 @@ describe("Db2Formatter", function() {
     });
 
     it("recognizes :variables", function() {
-        expect(sqlFormatter.format("SELECT :variable;", {language: "db2"})).toBe(
+        assert.equal(sqlFormatter.format("SELECT :variable;", {language: "db2"}),
             "SELECT\n" +
             "  :variable;"
         );
@@ -62,7 +64,7 @@ describe("Db2Formatter", function() {
             "SELECT :variable",
             {language: "db2", params: {"variable": "\"variable value\""}}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  \"variable value\""
         );

--- a/test/N1qlFormatterTest.js
+++ b/test/N1qlFormatterTest.js
@@ -1,12 +1,14 @@
 import sqlFormatter from "./../src/sqlFormatter";
 import behavesLikeSqlFormatter from "./behavesLikeSqlFormatter";
 
+import assert from 'assert';
+
 describe("N1qlFormatter", function() {
     behavesLikeSqlFormatter("n1ql");
 
     it("formats SELECT query with element selection expression", function() {
         const result = sqlFormatter.format("SELECT orderlines[0].productId FROM orders;", {language: "n1ql"});
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  orderlines[0].productId\n" +
             "FROM\n" +
@@ -19,7 +21,7 @@ describe("N1qlFormatter", function() {
             "SELECT fname, email FROM tutorial USE KEYS ['dave', 'ian'];",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  fname,\n" +
             "  email\n" +
@@ -35,7 +37,7 @@ describe("N1qlFormatter", function() {
             "INSERT INTO heroes (KEY, VALUE) VALUES ('123', {'id':1,'type':'Tarzan'});",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT INTO\n" +
             "  heroes (KEY, VALUE)\n" +
             "VALUES\n" +
@@ -49,7 +51,7 @@ describe("N1qlFormatter", function() {
             "'array': [123456789, 123456789, 123456789, 123456789, 123456789], 'hello': 'world'});",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT INTO\n" +
             "  heroes (KEY, VALUE)\n" +
             "VALUES\n" +
@@ -76,7 +78,7 @@ describe("N1qlFormatter", function() {
             "SELECT * FROM tutorial UNNEST tutorial.children c;",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FROM\n" +
@@ -93,7 +95,7 @@ describe("N1qlFormatter", function() {
             "ON KEYS ARRAY s.order_id FOR s IN usr.shipped_order_history END;",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FROM\n" +
@@ -110,7 +112,7 @@ describe("N1qlFormatter", function() {
             "EXPLAIN DELETE FROM tutorial t USE KEYS 'baldwin' RETURNING t",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "EXPLAIN DELETE FROM\n" +
             "  tutorial t\n" +
             "USE KEYS\n" +
@@ -123,7 +125,7 @@ describe("N1qlFormatter", function() {
             "UPDATE tutorial USE KEYS 'baldwin' SET type = 'actor' RETURNING tutorial.type",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "UPDATE\n" +
             "  tutorial\n" +
             "USE KEYS\n" +
@@ -138,7 +140,7 @@ describe("N1qlFormatter", function() {
             "SELECT $variable, $'var name', $\"var name\", $`var name`;",
             {language: "n1ql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  $variable,\n" +
             "  $'var name',\n" +
@@ -157,7 +159,7 @@ describe("N1qlFormatter", function() {
                 }
             }
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  \"variable value\",\n" +
             "  'var value',\n" +
@@ -175,7 +177,7 @@ describe("N1qlFormatter", function() {
                 2: "third"
             }
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  second,\n" +
             "  third,\n" +

--- a/test/PlSqlFormatterTest.js
+++ b/test/PlSqlFormatterTest.js
@@ -1,14 +1,16 @@
 import sqlFormatter from "./../src/sqlFormatter";
 import behavesLikeSqlFormatter from "./behavesLikeSqlFormatter";
 
+import assert from 'assert';
+
 describe("PlSqlFormatter", function() {
     behavesLikeSqlFormatter("pl/sql");
 
     it("formats FETCH FIRST like LIMIT", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;",
             {language: "pl/sql"}
-        )).toBe(
+        ),
             "SELECT\n" +
             "  col1\n" +
             "FROM\n" +
@@ -27,7 +29,7 @@ describe("PlSqlFormatter", function() {
             "MyTable;\n",
             {language: "pl/sql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  col\n" +
             "FROM\n" +
@@ -41,7 +43,7 @@ describe("PlSqlFormatter", function() {
             "SELECT my_col$1#, col.2@ FROM tbl\n",
             {language: "pl/sql"}
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  my_col$1#,\n" +
             "  col.2@\n" +
@@ -51,17 +53,17 @@ describe("PlSqlFormatter", function() {
     });
 
     it("formats short CREATE TABLE", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT);"
-        )).toBe(
+        ),
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT);"
         );
     });
 
     it("formats long CREATE TABLE", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT, c INT NOT NULL, d INT NOT NULL);"
-        )).toBe(
+        ),
             "CREATE TABLE items (\n" +
             "  a INT PRIMARY KEY,\n" +
             "  b TEXT,\n" +
@@ -75,7 +77,7 @@ describe("PlSqlFormatter", function() {
         const result = sqlFormatter.format(
             "INSERT Customers (ID, MoneyBalance, Address, City) VALUES (12,-123.4, 'Skagen 2111','Stv');"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT\n" +
             "  Customers (ID, MoneyBalance, Address, City)\n" +
             "VALUES\n" +
@@ -87,7 +89,7 @@ describe("PlSqlFormatter", function() {
         const result = sqlFormatter.format(
             "ALTER TABLE supplier MODIFY supplier_name char(100) NOT NULL;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "ALTER TABLE\n" +
             "  supplier\n" +
             "MODIFY\n" +
@@ -99,7 +101,7 @@ describe("PlSqlFormatter", function() {
         const result = sqlFormatter.format(
             "ALTER TABLE supplier ALTER COLUMN supplier_name VARCHAR(100) NOT NULL;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "ALTER TABLE\n" +
             "  supplier\n" +
             "ALTER COLUMN\n" +
@@ -108,15 +110,15 @@ describe("PlSqlFormatter", function() {
     });
 
     it("recognizes [] strings", function() {
-        expect(sqlFormatter.format("[foo JOIN bar]")).toBe("[foo JOIN bar]");
-        expect(sqlFormatter.format("[foo ]] JOIN bar]")).toBe("[foo ]] JOIN bar]");
+        assert.equal(sqlFormatter.format("[foo JOIN bar]"),"[foo JOIN bar]");
+        assert.equal(sqlFormatter.format("[foo ]] JOIN bar]"),"[foo ]] JOIN bar]");
     });
 
     it("recognizes :variables", function() {
         const result = sqlFormatter.format(
             "SELECT :variable, :a1_2.3$, :'var name', :\"var name\", :`var name`, :[var name];"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  :variable,\n" +
             "  :a1_2.3$,\n" +
@@ -141,7 +143,7 @@ describe("PlSqlFormatter", function() {
                 }
             }
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  \"variable value\",\n" +
             "  'weird value',\n" +
@@ -156,7 +158,7 @@ describe("PlSqlFormatter", function() {
 
     it("recognizes ?[0-9]* placeholders", function() {
         const result = sqlFormatter.format("SELECT ?1, ?25, ?;");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  ?1,\n" +
             "  ?25,\n" +
@@ -172,7 +174,7 @@ describe("PlSqlFormatter", function() {
                 2: "third"
             }
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  second,\n" +
             "  third,\n" +
@@ -184,7 +186,7 @@ describe("PlSqlFormatter", function() {
         const result = sqlFormatter.format("SELECT ?, ?, ?;", {
             params: ["first", "second", "third"]
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  first,\n" +
             "  second,\n" +
@@ -194,7 +196,7 @@ describe("PlSqlFormatter", function() {
 
     it("formats SELECT query with CROSS JOIN", function() {
         const result = sqlFormatter.format("SELECT a, b FROM t CROSS JOIN t2 on t.id = t2.id_t");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -205,8 +207,8 @@ describe("PlSqlFormatter", function() {
     });
 
     it("formats SELECT query with CROSS APPLY", function() {
-        const result = sqlFormatter.format("SELECT a, b FROM t CROSS APPLY fn(t.id)", );
-        expect(result).toBe(
+        const result = sqlFormatter.format("SELECT a, b FROM t CROSS APPLY fn(t.id)");
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -218,7 +220,7 @@ describe("PlSqlFormatter", function() {
 
     it("formats simple SELECT", function() {
         const result = sqlFormatter.format("SELECT N, M FROM t");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  N,\n" +
             "  M\n" +
@@ -229,7 +231,7 @@ describe("PlSqlFormatter", function() {
 
     it("formats simple SELECT with national characters", function() {
         const result = sqlFormatter.format("SELECT N'value'");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  N'value'"
         );
@@ -237,7 +239,7 @@ describe("PlSqlFormatter", function() {
 
     it("formats SELECT query with OUTER APPLY", function() {
         const result = sqlFormatter.format("SELECT a, b FROM t OUTER APPLY fn(t.id)");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -252,7 +254,7 @@ describe("PlSqlFormatter", function() {
             "CASE WHEN option = 'foo' THEN 1 WHEN option = 'bar' THEN 2 WHEN option = 'baz' THEN 3 ELSE 4 END;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "CASE\n" +
             "  WHEN option = 'foo' THEN 1\n" +
             "  WHEN option = 'bar' THEN 2\n" +
@@ -267,7 +269,7 @@ describe("PlSqlFormatter", function() {
             "SELECT foo, bar, CASE baz WHEN 'one' THEN 1 WHEN 'two' THEN 2 ELSE 3 END FROM table"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  foo,\n" +
             "  bar,\n" +
@@ -287,7 +289,7 @@ describe("PlSqlFormatter", function() {
             "CASE toString(getNumber()) WHEN 'one' THEN 1 WHEN 'two' THEN 2 WHEN 'three' THEN 3 ELSE 4 END;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "CASE\n" +
             "  toString(getNumber())\n" +
             "  WHEN 'one' THEN 1\n" +

--- a/test/StandardSqlFormatterTest.js
+++ b/test/StandardSqlFormatterTest.js
@@ -1,21 +1,23 @@
 import sqlFormatter from "./../src/sqlFormatter";
 import behavesLikeSqlFormatter from "./behavesLikeSqlFormatter";
 
+import assert from 'assert';
+
 describe("StandardSqlFormatter", function() {
     behavesLikeSqlFormatter();
 
     it("formats short CREATE TABLE", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT);"
-        )).toBe(
+        ),
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT);"
         );
     });
 
     it("formats long CREATE TABLE", function() {
-        expect(sqlFormatter.format(
+        assert.equal(sqlFormatter.format(
             "CREATE TABLE items (a INT PRIMARY KEY, b TEXT, c INT NOT NULL, d INT NOT NULL);"
-        )).toBe(
+        ),
             "CREATE TABLE items (\n" +
             "  a INT PRIMARY KEY,\n" +
             "  b TEXT,\n" +
@@ -29,7 +31,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format(
             "INSERT Customers (ID, MoneyBalance, Address, City) VALUES (12,-123.4, 'Skagen 2111','Stv');"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT\n" +
             "  Customers (ID, MoneyBalance, Address, City)\n" +
             "VALUES\n" +
@@ -41,7 +43,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format(
             "ALTER TABLE supplier MODIFY supplier_name char(100) NOT NULL;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "ALTER TABLE\n" +
             "  supplier\n" +
             "MODIFY\n" +
@@ -53,7 +55,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format(
             "ALTER TABLE supplier ALTER COLUMN supplier_name VARCHAR(100) NOT NULL;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "ALTER TABLE\n" +
             "  supplier\n" +
             "ALTER COLUMN\n" +
@@ -62,15 +64,15 @@ describe("StandardSqlFormatter", function() {
     });
 
     it("recognizes [] strings", function() {
-        expect(sqlFormatter.format("[foo JOIN bar]")).toBe("[foo JOIN bar]");
-        expect(sqlFormatter.format("[foo ]] JOIN bar]")).toBe("[foo ]] JOIN bar]");
+        assert.equal(sqlFormatter.format("[foo JOIN bar]"), "[foo JOIN bar]");
+        assert.equal(sqlFormatter.format("[foo ]] JOIN bar]"), "[foo ]] JOIN bar]");
     });
 
     it("recognizes @variables", function() {
         const result = sqlFormatter.format(
             "SELECT @variable, @a1_2.3$, @'var name', @\"var name\", @`var name`, @[var name];"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  @variable,\n" +
             "  @a1_2.3$,\n" +
@@ -93,7 +95,7 @@ describe("StandardSqlFormatter", function() {
                 }
             }
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  \"variable value\",\n" +
             "  'weird value',\n" +
@@ -109,7 +111,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format(
             "SELECT :variable, :a1_2.3$, :'var name', :\"var name\", :`var name`, :[var name];"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  :variable,\n" +
             "  :a1_2.3$,\n" +
@@ -134,7 +136,7 @@ describe("StandardSqlFormatter", function() {
                 }
             }
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  \"variable value\",\n" +
             "  'weird value',\n" +
@@ -149,7 +151,7 @@ describe("StandardSqlFormatter", function() {
 
     it("recognizes ?[0-9]* placeholders", function() {
         const result = sqlFormatter.format("SELECT ?1, ?25, ?;");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  ?1,\n" +
             "  ?25,\n" +
@@ -165,7 +167,7 @@ describe("StandardSqlFormatter", function() {
                 2: "third"
             }
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  second,\n" +
             "  third,\n" +
@@ -177,7 +179,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format("SELECT ?, ?, ?;", {
             params: ["first", "second", "third"]
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  first,\n" +
             "  second,\n" +
@@ -189,7 +191,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format("SELECT 1 GO SELECT 2", {
             params: ["first", "second", "third"]
         });
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  1\n" +
             "GO\n" +
@@ -200,7 +202,7 @@ describe("StandardSqlFormatter", function() {
 
     it("formats SELECT query with CROSS JOIN", function() {
         const result = sqlFormatter.format("SELECT a, b FROM t CROSS JOIN t2 on t.id = t2.id_t");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -212,7 +214,7 @@ describe("StandardSqlFormatter", function() {
 
     it("formats SELECT query with CROSS APPLY", function() {
         const result = sqlFormatter.format("SELECT a, b FROM t CROSS APPLY fn(t.id)");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -224,7 +226,7 @@ describe("StandardSqlFormatter", function() {
 
     it("formats simple SELECT", function() {
         const result = sqlFormatter.format("SELECT N, M FROM t");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  N,\n" +
             "  M\n" +
@@ -235,7 +237,7 @@ describe("StandardSqlFormatter", function() {
 
     it("formats simple SELECT with national characters (MSSQL)", function() {
         const result = sqlFormatter.format("SELECT N'value'");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  N'value'"
         );
@@ -243,7 +245,7 @@ describe("StandardSqlFormatter", function() {
 
     it("formats SELECT query with OUTER APPLY", function() {
         const result = sqlFormatter.format("SELECT a, b FROM t OUTER APPLY fn(t.id)");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  a,\n" +
             "  b\n" +
@@ -257,7 +259,7 @@ describe("StandardSqlFormatter", function() {
         const result = sqlFormatter.format(
             "SELECT * FETCH FIRST 2 ROWS ONLY;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FETCH FIRST\n" +
@@ -270,7 +272,7 @@ describe("StandardSqlFormatter", function() {
             "CASE WHEN option = 'foo' THEN 1 WHEN option = 'bar' THEN 2 WHEN option = 'baz' THEN 3 ELSE 4 END;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "CASE\n" +
             "  WHEN option = 'foo' THEN 1\n" +
             "  WHEN option = 'bar' THEN 2\n" +
@@ -285,7 +287,7 @@ describe("StandardSqlFormatter", function() {
             "SELECT foo, bar, CASE baz WHEN 'one' THEN 1 WHEN 'two' THEN 2 ELSE 3 END FROM table"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  foo,\n" +
             "  bar,\n" +
@@ -305,7 +307,7 @@ describe("StandardSqlFormatter", function() {
             "CASE toString(getNumber()) WHEN 'one' THEN 1 WHEN 'two' THEN 2 WHEN 'three' THEN 3 ELSE 4 END;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "CASE\n" +
             "  toString(getNumber())\n" +
             "  WHEN 'one' THEN 1\n" +
@@ -321,7 +323,7 @@ describe("StandardSqlFormatter", function() {
             "case when option = 'foo' then 1 else 2 end;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "case\n" +
             "  when option = 'foo' then 1\n" +
             "  else 2\n" +
@@ -335,7 +337,7 @@ describe("StandardSqlFormatter", function() {
             "SELECT CASEDATE, ENDDATE FROM table1;"
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  CASEDATE,\n" +
             "  ENDDATE\n" +
@@ -345,7 +347,7 @@ describe("StandardSqlFormatter", function() {
     });
 
     it("formats tricky line comments", function() {
-        expect(sqlFormatter.format("SELECT a#comment, here\nFROM b--comment")).toBe(
+        assert.equal(sqlFormatter.format("SELECT a#comment, here\nFROM b--comment"),
             "SELECT\n" +
             "  a #comment, here\n" +
             "FROM\n" +

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -1,5 +1,7 @@
 import sqlFormatter from "./../src/sqlFormatter";
 
+import assert from 'assert';
+
 /**
  * Core tests for all SQL formatters
  * @param {String} language
@@ -11,7 +13,7 @@ export default function behavesLikeSqlFormatter(language) {
             {language, indent: "    "}
         );
 
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "    count(*),\n" +
             "    Column1\n" +
@@ -26,7 +28,7 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats simple SET SCHEMA queries", function() {
         const result = format("SET SCHEMA tetrisdb; SET CURRENT SCHEMA bingodb;");
-        expect(result).toBe(
+        assert.equal(result, 
             "SET SCHEMA\n" +
             "  tetrisdb;\n" +
             "SET CURRENT SCHEMA\n" +
@@ -36,7 +38,7 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats simple SELECT query", function() {
         const result = format("SELECT count(*),Column1 FROM Table1;");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  count(*),\n" +
             "  Column1\n" +
@@ -49,7 +51,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "SELECT DISTINCT name, ROUND(age/7) field1, 18 + 20 AS field2, 'some string' FROM foo;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  DISTINCT name,\n" +
             "  ROUND(age / 7) field1,\n" +
@@ -65,7 +67,7 @@ export default function behavesLikeSqlFormatter(language) {
             "SELECT * FROM foo WHERE Column1 = 'testing'" +
             "AND ( (Column2 = Column3 OR Column4 >= NOW()) );"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FROM\n" +
@@ -86,7 +88,7 @@ export default function behavesLikeSqlFormatter(language) {
             "SELECT * FROM foo WHERE name = 'John' GROUP BY some_column " +
             "HAVING column > 10 ORDER BY other_column LIMIT 5;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FROM\n" +
@@ -108,7 +110,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "LIMIT 5, 10;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "LIMIT\n" +
             "  5, 10;"
         );
@@ -118,7 +120,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "LIMIT 5; SELECT foo, bar;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "LIMIT\n" +
             "  5;\n" +
             "SELECT\n" +
@@ -131,7 +133,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "LIMIT 5 OFFSET 8;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "LIMIT\n" +
             "  5 OFFSET 8;"
         );
@@ -141,7 +143,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "limit 5, 10;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "limit\n" +
             "  5, 10;"
         );
@@ -151,7 +153,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "select distinct * frOM foo left join bar WHERe a > 1 and b = 3"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "select\n" +
             "  distinct *\n" +
             "frOM\n" +
@@ -167,7 +169,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "SELECT *, SUM(*) AS sum FROM (SELECT * FROM Posts LIMIT 30) WHERE a > b"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *,\n" +
             "  SUM(*) AS sum\n" +
@@ -190,7 +192,7 @@ export default function behavesLikeSqlFormatter(language) {
             "SELECT customer_id.from, COUNT(order_id) AS total FROM customers " +
             "INNER JOIN orders ON customers.customer_id = orders.customer_id;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  customer_id.from,\n" +
             "  COUNT(order_id) AS total\n" +
@@ -211,7 +213,7 @@ export default function behavesLikeSqlFormatter(language) {
             "MyTable # One final comment\n" +
             "WHERE 1 = 2;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  /*\n" +
             "   * This is a block comment\n" +
@@ -229,7 +231,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "INSERT INTO Customers (ID, MoneyBalance, Address, City) VALUES (12,-123.4, 'Skagen 2111','Stv');"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT INTO\n" +
             "  Customers (ID, MoneyBalance, Address, City)\n" +
             "VALUES\n" +
@@ -241,7 +243,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "SELECT (a + b * (c - NOW()));"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  (a + b * (c - NOW()));"
         );
@@ -253,7 +255,7 @@ export default function behavesLikeSqlFormatter(language) {
             "SELECT IF(dq.id_discounter_shopping = 2, dq.value, dq.value / 100)," +
             "IF (dq.id_discounter_shopping = 2, 'amount', 'percentage') FROM foo);"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "INSERT INTO\n" +
             "  some_table (\n" +
             "    id_product,\n" +
@@ -283,7 +285,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "UPDATE Customers SET ContactName='Alfred Schmidt', City='Hamburg' WHERE CustomerName='Alfreds Futterkiste';"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "UPDATE\n" +
             "  Customers\n" +
             "SET\n" +
@@ -298,7 +300,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "DELETE FROM Customers WHERE CustomerName='Alfred' AND Phone=5002132;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "DELETE FROM\n" +
             "  Customers\n" +
             "WHERE\n" +
@@ -311,14 +313,14 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "DROP TABLE IF EXISTS admin_role;"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "DROP TABLE IF EXISTS admin_role;"
         );
     });
 
     it("formats uncomplete query", function() {
         const result = format("SELECT count(");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  count("
         );
@@ -326,7 +328,7 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats query that ends with open comment", function() {
         const result = format("SELECT count(*)\n/*Comment");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  count(*)\n" +
             "  /*Comment"
@@ -337,7 +339,7 @@ export default function behavesLikeSqlFormatter(language) {
         const result = format(
             "UPDATE customers SET totalorders = ordersummary.total  FROM ( SELECT * FROM bank) AS ordersummary"
         );
-        expect(result).toBe(
+        assert.equal(result, 
             "UPDATE\n" +
             "  customers\n" +
             "SET\n" +
@@ -354,7 +356,7 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats top-level and newline multi-word reserved words with inconsistent spacing", function() {
         const result = format("SELECT * FROM foo LEFT \t OUTER  \n JOIN bar ORDER \n BY blah");
-        expect(result).toBe(
+        assert.equal(result, 
             "SELECT\n" +
             "  *\n" +
             "FROM\n" +
@@ -367,7 +369,7 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats long double parenthized queries to multiple lines", function() {
         const result = format("((foo = '0123456789-0123456789-0123456789-0123456789'))");
-        expect(result).toBe(
+        assert.equal(result, 
             "(\n" +
             "  (\n" +
             "    foo = '0123456789-0123456789-0123456789-0123456789'\n" +
@@ -378,71 +380,71 @@ export default function behavesLikeSqlFormatter(language) {
 
     it("formats short double parenthized queries to one line", function() {
         const result = format("((foo = 'bar'))");
-        expect(result).toBe("((foo = 'bar'))");
+        assert.equal(result, "((foo = 'bar'))");
     });
 
     it("formats single-char operators", function() {
-        expect(format("foo = bar")).toBe("foo = bar");
-        expect(format("foo < bar")).toBe("foo < bar");
-        expect(format("foo > bar")).toBe("foo > bar");
-        expect(format("foo + bar")).toBe("foo + bar");
-        expect(format("foo - bar")).toBe("foo - bar");
-        expect(format("foo * bar")).toBe("foo * bar");
-        expect(format("foo / bar")).toBe("foo / bar");
-        expect(format("foo % bar")).toBe("foo % bar");
+        assert.equal(format("foo = bar"), "foo = bar");
+        assert.equal(format("foo < bar"), "foo < bar");
+        assert.equal(format("foo > bar"), "foo > bar");
+        assert.equal(format("foo + bar"), "foo + bar");
+        assert.equal(format("foo - bar"), "foo - bar");
+        assert.equal(format("foo * bar"), "foo * bar");
+        assert.equal(format("foo / bar"), "foo / bar");
+        assert.equal(format("foo % bar"), "foo % bar");
     });
 
     it("formats multi-char operators", function() {
-        expect(format("foo != bar")).toBe("foo != bar");
-        expect(format("foo <> bar")).toBe("foo <> bar");
-        expect(format("foo == bar")).toBe("foo == bar"); // N1QL
-        expect(format("foo || bar")).toBe("foo || bar"); // Oracle, Postgres, N1QL string concat
+        assert.equal(format("foo != bar"), "foo != bar");
+        assert.equal(format("foo <> bar"), "foo <> bar");
+        assert.equal(format("foo == bar"), "foo == bar"); // N1QL
+        assert.equal(format("foo || bar"), "foo || bar"); // Oracle, Postgres, N1QL string concat
 
-        expect(format("foo <= bar")).toBe("foo <= bar");
-        expect(format("foo >= bar")).toBe("foo >= bar");
+        assert.equal(format("foo <= bar"), "foo <= bar");
+        assert.equal(format("foo >= bar"), "foo >= bar");
 
-        expect(format("foo !< bar")).toBe("foo !< bar");
-        expect(format("foo !> bar")).toBe("foo !> bar");
+        assert.equal(format("foo !< bar"), "foo !< bar");
+        assert.equal(format("foo !> bar"), "foo !> bar");
     });
 
     it("formats logical operators", function() {
-        expect(format("foo ALL bar")).toBe("foo ALL bar");
-        expect(format("foo = ANY (1, 2, 3)")).toBe("foo = ANY (1, 2, 3)");
-        expect(format("EXISTS bar")).toBe("EXISTS bar");
-        expect(format("foo IN (1, 2, 3)")).toBe("foo IN (1, 2, 3)");
-        expect(format("foo LIKE 'hello%'")).toBe("foo LIKE 'hello%'");
-        expect(format("foo IS NULL")).toBe("foo IS NULL");
-        expect(format("UNIQUE foo")).toBe("UNIQUE foo");
+        assert.equal(format("foo ALL bar"), "foo ALL bar");
+        assert.equal(format("foo = ANY (1, 2, 3)"), "foo = ANY (1, 2, 3)");
+        assert.equal(format("EXISTS bar"), "EXISTS bar");
+        assert.equal(format("foo IN (1, 2, 3)"), "foo IN (1, 2, 3)");
+        assert.equal(format("foo LIKE 'hello%'"), "foo LIKE 'hello%'");
+        assert.equal(format("foo IS NULL"), "foo IS NULL");
+        assert.equal(format("UNIQUE foo"), "UNIQUE foo");
     });
 
     it("formats AND/OR operators", function() {
-        expect(format("foo BETWEEN bar AND baz")).toBe("foo BETWEEN bar\nAND baz");
-        expect(format("foo AND bar")).toBe("foo\nAND bar");
-        expect(format("foo OR bar")).toBe("foo\nOR bar");
+        assert.equal(format("foo BETWEEN bar AND baz"), "foo BETWEEN bar\nAND baz");
+        assert.equal(format("foo AND bar"), "foo\nAND bar");
+        assert.equal(format("foo OR bar"), "foo\nOR bar");
     });
 
     it("recognizes strings", function() {
-        expect(format("\"foo JOIN bar\"")).toBe("\"foo JOIN bar\"");
-        expect(format("'foo JOIN bar'")).toBe("'foo JOIN bar'");
-        expect(format("`foo JOIN bar`")).toBe("`foo JOIN bar`");
+        assert.equal(format("\"foo JOIN bar\""), "\"foo JOIN bar\"");
+        assert.equal(format("'foo JOIN bar'"), "'foo JOIN bar'");
+        assert.equal(format("`foo JOIN bar`"), "`foo JOIN bar`");
     });
 
     it("recognizes escaped strings", function() {
-        expect(format("\"foo \\\" JOIN bar\"")).toBe("\"foo \\\" JOIN bar\"");
-        expect(format("'foo \\' JOIN bar'")).toBe("'foo \\' JOIN bar'");
-        expect(format("`foo `` JOIN bar`")).toBe("`foo `` JOIN bar`");
+        assert.equal(format("\"foo \\\" JOIN bar\""), "\"foo \\\" JOIN bar\"");
+        assert.equal(format("'foo \\' JOIN bar'"), "'foo \\' JOIN bar'");
+        assert.equal(format("`foo `` JOIN bar`"), "`foo `` JOIN bar`");
     });
 
     it("formats postgres specific operators", function() {
-        expect(format("column::int")).toBe("column :: int");
-        expect(format("v->2")).toBe("v -> 2");
-        expect(format("v->>2")).toBe( "v ->> 2");
-        expect(format("foo ~~ 'hello'")).toBe("foo ~~ 'hello'");
-        expect(format("foo !~ 'hello'")).toBe("foo !~ 'hello'");
-        expect(format("foo ~* 'hello'")).toBe("foo ~* 'hello'");
-        expect(format("foo ~~* 'hello'")).toBe("foo ~~* 'hello'");
-        expect(format("foo !~~ 'hello'")).toBe("foo !~~ 'hello'");
-        expect(format("foo !~* 'hello'")).toBe("foo !~* 'hello'");
-        expect(format("foo !~~* 'hello'")).toBe("foo !~~* 'hello'");
+        assert.equal(format("column::int"), "column :: int");
+        assert.equal(format("v->2"), "v -> 2");
+        assert.equal(format("v->>2"),  "v ->> 2");
+        assert.equal(format("foo ~~ 'hello'"), "foo ~~ 'hello'");
+        assert.equal(format("foo !~ 'hello'"), "foo !~ 'hello'");
+        assert.equal(format("foo ~* 'hello'"), "foo ~* 'hello'");
+        assert.equal(format("foo ~~* 'hello'"), "foo ~~* 'hello'");
+        assert.equal(format("foo !~~ 'hello'"), "foo !~~ 'hello'");
+        assert.equal(format("foo !~* 'hello'"), "foo !~* 'hello'");
+        assert.equal(format("foo !~~* 'hello'"), "foo !~~* 'hello'");
     });
 }

--- a/test/sqlFormatterTest.js
+++ b/test/sqlFormatterTest.js
@@ -6,6 +6,6 @@ describe("sqlFormatter", function() {
     it("throws error when unsupported language parameter specified", function() {
         assert.throws(() => {
             sqlFormatter.format("SELECT *", {language: "blah"});
-        }, "Unsupported SQL dialect: blah");
+        }, new Error ("Unsupported SQL dialect: blah"));
     });
 });

--- a/test/sqlFormatterTest.js
+++ b/test/sqlFormatterTest.js
@@ -1,9 +1,11 @@
 import sqlFormatter from "./../src/sqlFormatter";
 
+import assert from 'assert';
+
 describe("sqlFormatter", function() {
     it("throws error when unsupported language parameter specified", function() {
-        expect(() => {
+        assert.throws(() => {
             sqlFormatter.format("SELECT *", {language: "blah"});
-        }).toThrow("Unsupported SQL dialect: blah");
+        }, "Unsupported SQL dialect: blah");
     });
 });


### PR DESCRIPTION
To me, it is not a good idea to install `babel-runtime` just for es module `import`. So, I replaced babel with [esm](https://github.com/standard-things/esm). Unfortunately, `jest` have no idea of es modules and [needs](https://github.com/facebook/jest/issues/4842) [pretty heavy patches](https://github.com/kenotron/esm-jest/), so I've used `mocha` and node's `assert`.