### PR TITLE
Formatter adds semicolon onto last line inside of line comment

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -74,7 +74,13 @@ export default class Formatter {
                 formattedQuery = this.formatWithSpaceAfter(token, formattedQuery);
             }
             else if (token.value === "." || token.value === ";") {
-                formattedQuery = this.formatWithoutSpaces(token, formattedQuery);
+                // if the previous token was a line comment, do not allow the newline to be trimmed
+                if (tokens[index - 1].type === tokenTypes.LINE_COMMENT) {
+                    formattedQuery = this.formatWithNewlines(token, formattedQuery);
+                } 
+                else {
+                    formattedQuery = this.formatWithoutSpaces(token, formattedQuery);
+                }
             }
             else {
                 formattedQuery = this.formatWithSpaces(token, formattedQuery);
@@ -174,6 +180,10 @@ export default class Formatter {
 
     formatWithSpaces(token, query) {
         return query + token.value + " ";
+    }
+
+    formatWithNewlines(token, query) {
+        return trimEnd(query, " ") + token.value;
     }
 
     addNewline(query) {

--- a/test/StandardSqlFormatterTest.js
+++ b/test/StandardSqlFormatterTest.js
@@ -352,4 +352,14 @@ describe("StandardSqlFormatter", function() {
             "  b --comment"
         );
     });
+
+    it("formats line comments without adding semicolon to same line", function() {
+        expect(sqlFormatter.format("SELECT a FROM b\n--comment\n;")).toBe(
+            "SELECT\n" +
+            "  a\n" +
+            "FROM\n" +
+            "  b --comment\n" +
+            ";"
+        );
+    });
 });


### PR DESCRIPTION
When inputting a line comment on the line above the semicolon, the semicolon is formatted onto that line. When the query is executed, it is missing a semicolon and may be considered incomplete SQL.

Query:

```
SELECT * FROM user
-- no where clause here
;
```
Expected:

```
SELECT
  *
FROM
  user 
-- no where clause here
;
```
Actual:

```
SELECT
  *
FROM
  user -- no where clause here;
```