### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ It supports [Standard SQL][], [Couchbase N1QL][], [IBM DB2][] and [Oracle PL/SQL
 Get the latest version from NPM:
 
 ```
-npm install --save sql-formatter
+npm install --save-dev sql-formatter
 ```
 
 ## Usage
 
 ```js
-import sqlFormatter from "sql-formatter";
+const sqlFormatter = require("sql-formatter");
 
 console.log(sqlFormatter.format("SELECT * FROM table1"));
 ```


### PR DESCRIPTION
--save is deprecated in `npm i`

I suppose using `require` is cleaner than import as it is standard in node