### PR TITLE
comment line maybe crlf

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -43,7 +43,7 @@ export default class Tokenizer {
     }
 
     createLineCommentRegex(lineCommentTypes) {
-        return new RegExp(`^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join("|")}).*?(?:\n|$))`);
+        return new RegExp(`^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join("|")}).*?(?:\n|\r\n|$))`);
     }
 
     createReservedWordRegex(reservedWords) {


### PR DESCRIPTION
My project has the problem that when users copy the sql from windows platform, formatter cannot match the sql of comment，instead of thinking them as the operators.

before
![image](https://user-images.githubusercontent.com/14807468/53707327-76f88f00-3e69-11e9-9dc2-c88e9ea68f60.png)

after
![image](https://user-images.githubusercontent.com/14807468/53707360-9a233e80-3e69-11e9-8a19-2f808e279a80.png)

so I add the reg `\r\n`
