### PR TITLE
Allow networked imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Currently just four SQL dialects are supported:
 // Named placeholders
 sqlFormatter.format("SELECT * FROM tbl WHERE foo = @foo", {
     params: {foo: "'bar'"}
-}));
+});
 
 // Indexed placeholders
 sqlFormatter.format("SELECT * FROM tbl WHERE foo = ?", {
     params: ["'bar'"]
-}));
+});
 ```
 
 Both result in:
@@ -76,6 +76,14 @@ WHERE
 
 If you don't use a module bundler, clone the repository, run `npm install` and grab a file from `/dist` directory to use inside a `<script>` tag.
 This makes SQL Formatter available as a global variable `window.sqlFormatter`.
+
+To use native imports, clone and then import files directly within ES6 modules:
+
+```js
+import sqlFormatter from '<PATH-TO-CLONED-REPO>/src/sqlFormatter.js';
+
+sqlFormatter.format("SELECT * FROM table1");
+```
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4163,7 +4163,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
   "bugs": {
     "url": "https://github.com/zeroturnaround/sql-formatter/issues"
   },
-  "dependencies": {
-    "lodash": "^4.16.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-core": "^6.11.4",

--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -1,7 +1,7 @@
-import tokenTypes from "./tokenTypes";
-import Indentation from "./Indentation";
-import InlineBlock from "./InlineBlock";
-import Params from "./Params";
+import tokenTypes from "./tokenTypes.js";
+import Indentation from "./Indentation.js";
+import InlineBlock from "./InlineBlock.js";
+import Params from "./Params.js";
 
 const trimEnd = string => string.replace(/\s+$/, '');
 

--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -1,8 +1,9 @@
-import trimEnd from "lodash/trimEnd";
 import tokenTypes from "./tokenTypes";
 import Indentation from "./Indentation";
 import InlineBlock from "./InlineBlock";
 import Params from "./Params";
+
+const trimEnd = string => string.replace(/\s+$/, '');
 
 export default class Formatter {
     /**

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -1,6 +1,3 @@
-import repeat from "lodash/repeat";
-import last from "lodash/last";
-
 const INDENT_TYPE_TOP_LEVEL = "top-level";
 const INDENT_TYPE_BLOCK_LEVEL = "block-level";
 
@@ -26,7 +23,7 @@ export default class Indentation {
      * @return {String}
      */
     getIndent() {
-        return repeat(this.indent, this.indentTypes.length);
+        return this.indent.repeat(this.indentTypes.length);
     }
 
     /**
@@ -48,7 +45,8 @@ export default class Indentation {
      * Does nothing when the previous indent is not top-level.
      */
     decreaseTopLevel() {
-        if (last(this.indentTypes) === INDENT_TYPE_TOP_LEVEL) {
+        const lastIndentType = this.indentTypes[this.indentTypes.length - 1];
+        if (lastIndentType === INDENT_TYPE_TOP_LEVEL) {
             this.indentTypes.pop();
         }
     }

--- a/src/core/InlineBlock.js
+++ b/src/core/InlineBlock.js
@@ -1,4 +1,4 @@
-import tokenTypes from "./tokenTypes";
+import tokenTypes from "./tokenTypes.js";
 
 const INLINE_MAX_LENGTH = 50;
 

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -1,6 +1,9 @@
-import isEmpty from "lodash/isEmpty";
-import escapeRegExp from "lodash/escapeRegExp";
 import tokenTypes from "./tokenTypes";
+
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
 
 export default class Tokenizer {
     /**
@@ -98,7 +101,7 @@ export default class Tokenizer {
     }
 
     createPlaceholderRegex(types, pattern) {
-        if (isEmpty(types)) {
+        if (Array.isArray(types) === false || types.length === 0) {
             return false;
         }
         const typesRegex = types.map(escapeRegExp).join("|");

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -1,4 +1,4 @@
-import tokenTypes from "./tokenTypes";
+import tokenTypes from "./tokenTypes.js";
 
 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 function escapeRegExp(string) {

--- a/src/languages/Db2Formatter.js
+++ b/src/languages/Db2Formatter.js
@@ -1,5 +1,5 @@
-import Formatter from "../core/Formatter";
-import Tokenizer from "../core/Tokenizer";
+import Formatter from "../core/Formatter.js";
+import Tokenizer from "../core/Tokenizer.js";
 
 const reservedWords = [
     "ABS", "ACTIVATE", "ALIAS", "ALL", "ALLOCATE", "ALLOW", "ALTER", "ANY", "ARE", "ARRAY", "AS", "ASC",

--- a/src/languages/N1qlFormatter.js
+++ b/src/languages/N1qlFormatter.js
@@ -1,5 +1,5 @@
-import Formatter from "../core/Formatter";
-import Tokenizer from "../core/Tokenizer";
+import Formatter from "../core/Formatter.js";
+import Tokenizer from "../core/Tokenizer.js";
 
 const reservedWords = [
     "ALL", "ALTER", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC",

--- a/src/languages/PlSqlFormatter.js
+++ b/src/languages/PlSqlFormatter.js
@@ -1,5 +1,5 @@
-import Formatter from "../core/Formatter";
-import Tokenizer from "../core/Tokenizer";
+import Formatter from "../core/Formatter.js";
+import Tokenizer from "../core/Tokenizer.js";
 
 const reservedWords = [
     "A", "ACCESSIBLE", "AGENT", "AGGREGATE", "ALL", "ALTER", "ANY", "ARRAY", "AS", "ASC", "AT", "ATTRIBUTE", "AUTHID", "AVG",

--- a/src/languages/StandardSqlFormatter.js
+++ b/src/languages/StandardSqlFormatter.js
@@ -1,5 +1,5 @@
-import Formatter from "../core/Formatter";
-import Tokenizer from "../core/Tokenizer";
+import Formatter from "../core/Formatter.js";
+import Tokenizer from "../core/Tokenizer.js";
 
 const reservedWords = [
     "ACCESSIBLE", "ACTION", "AGAINST", "AGGREGATE", "ALGORITHM", "ALL", "ALTER", "ANALYSE", "ANALYZE", "AS", "ASC", "AUTOCOMMIT",

--- a/src/sqlFormatter.js
+++ b/src/sqlFormatter.js
@@ -1,7 +1,7 @@
-import Db2Formatter from "./languages/Db2Formatter";
-import N1qlFormatter from "./languages/N1qlFormatter";
-import PlSqlFormatter from "./languages/PlSqlFormatter";
-import StandardSqlFormatter from "./languages/StandardSqlFormatter";
+import Db2Formatter from "./languages/Db2Formatter.js";
+import N1qlFormatter from "./languages/N1qlFormatter.js";
+import PlSqlFormatter from "./languages/PlSqlFormatter.js";
+import StandardSqlFormatter from "./languages/StandardSqlFormatter.js";
 
 export default {
     /**


### PR DESCRIPTION
Hello, I was looking to try out this repo in a project, but I'm only using native ES6 imports, which prevented me from trying this out. I took a look and it seemed like it would be pretty simple to open a PR to allow this sort of usage.

This PR:

1. removes `lodash` (seemed pretty easy to support things natively)
2. adds support for usage via native ES6 imports

No rush on this, but I was going to make these updates anyhow and figured you might be interested in them as well 👍