### PR TITLE
use `lodash/includes` instead of `Array.prototype.includes`

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -1,3 +1,4 @@
+import includes from "lodash/includes";
 import trimEnd from "lodash/trimEnd";
 import tokenTypes from "./tokenTypes";
 import Indentation from "./Indentation";
@@ -131,7 +132,7 @@ export default class Formatter {
             tokenTypes.OPEN_PAREN,
             tokenTypes.LINE_COMMENT,
         ];
-        if (!preserveWhitespaceFor.includes(this.previousToken().type)) {
+        if (!includes(preserveWhitespaceFor, this.previousToken().type)) {
             query = trimEnd(query);
         }
         query += token.value;


### PR DESCRIPTION
in order to be able to use the library in IE11 without needing a polyfill