### PR TITLE
reset indentation for new queries

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -190,6 +190,7 @@ export default class Formatter {
     }
 
     formatQuerySeparator(token, query) {
+        this.indentation.decreaseTopLevel();
         return this.trimTrailingWhitespace(query) + token.value + "\n";
     }
 

--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -190,7 +190,7 @@ export default class Formatter {
     }
 
     formatQuerySeparator(token, query) {
-        this.indentation.decreaseTopLevel();
+        this.indentation.resetIndentation();
         return this.trimTrailingWhitespace(query) + token.value + "\n";
     }
 

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -52,10 +52,6 @@ export default class Indentation {
             this.indentTypes.pop();
         }
     }
-    
-    resetIndentation() {
-        this.indentTypes = [];
-    }
 
     /**
      * Decreases indentation by one block-level indent.
@@ -69,5 +65,9 @@ export default class Indentation {
                 break;
             }
         }
+    }
+    
+    resetIndentation() {
+        this.indentTypes = [];
     }
 }

--- a/src/core/Indentation.js
+++ b/src/core/Indentation.js
@@ -52,6 +52,10 @@ export default class Indentation {
             this.indentTypes.pop();
         }
     }
+    
+    resetIndentation() {
+        this.indentTypes = [];
+    }
 
     /**
      * Decreases indentation by one block-level indent.

--- a/test/StandardSqlFormatterTest.js
+++ b/test/StandardSqlFormatterTest.js
@@ -391,4 +391,22 @@ describe("StandardSqlFormatter", function() {
     it("formats lonely semicolon", function() {
         expect(sqlFormatter.format(";")).toBe(";");
     });
+    
+    it('correctly indents create statement after select', () => {
+        const result = sqlFormatter.format(`
+            SELECT * FROM test;
+            CREATE TABLE TEST(id NUMBER NOT NULL, col1 VARCHAR2(20), col2 VARCHAR2(20));
+        `);
+        expect(result).toBe(
+            "SELECT\n" +
+            "  *\n" +
+            "FROM\n" +
+            "  test;\n" +
+            "CREATE TABLE TEST(\n" +
+            "  id NUMBER NOT NULL,\n" +
+            "  col1 VARCHAR2(20),\n" +
+            "  col2 VARCHAR2(20)\n" +
+            ");"
+        );
+    });
 });


### PR DESCRIPTION
```sql
select * from test;
CREATE TABLE TEST(id NUMBER NOT NULL, col1 VARCHAR2(20), col2 VARCHAR2(20));
```
was getting formatted like

```sql
SELECT
  *
FROM
  test;
CREATE TABLE TEST(
    id NUMBER NOT NULL,
    col1 VARCHAR2(20),
    col2 VARCHAR2(20)
  );
```
this fixes it
