### PR TITLE
Add support for PG bitwise shift, square / cube root, and absolute value operators.

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -19,7 +19,7 @@ export default class Tokenizer {
     constructor(cfg) {
         this.WHITESPACE_REGEX = /^(\s+)/;
         this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/;
-        this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|.)/;
+        this.OPERATOR_REGEX = /^(!=|<<|>>|<>|==|<=|>=|!<|!>|\|\|\/|\|\/|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|@|.)/;
 
         this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/;
         this.LINE_COMMENT_REGEX = this.createLineCommentRegex(cfg.lineCommentTypes);

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -444,6 +444,11 @@ export default function behavesLikeSqlFormatter(language) {
         expect(format("foo !~~ 'hello'")).toBe("foo !~~ 'hello'");
         expect(format("foo !~* 'hello'")).toBe("foo !~* 'hello'");
         expect(format("foo !~~* 'hello'")).toBe("foo !~~* 'hello'");
+        expect(format("@ foo")).toBe("@ foo");
+        expect(format("foo << 2")).toBe("foo << 2");
+        expect(format("foo >> 2")).toBe("foo >> 2");
+        expect(format("|/ foo")).toBe("|/ foo");
+        expect(format("||/ foo")).toBe("||/ foo");
     });
 
     it("keeps separation between multiple statements", function() {


### PR DESCRIPTION
Added support for the following operators:
* @ absolute value (wasn't really a problem, but added it to the regex anyway)
* |/ (square root)
* ||/ (cube root)
* << (bitwise shift left)
* \>> (bitwise shift right)