### PR TITLE
Update lodash to fix CVE-2020-8203

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sql-formatter",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4180,9 +4180,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/zeroturnaround/sql-formatter/issues"
   },
   "dependencies": {
-    "lodash": "^4.16.0"
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
I'm wondering if you would consider merging this pull request and pushing a new version to npmjs.com.

All lodash versions lower than 4.17.20 have some sort of security vulnerability, for example, [CVE-2020-8203](https://nvd.nist.gov/vuln/detail/CVE-2020-8203). Lodash 4.17.20 fixes these vulnerabilities.