### PR TITLE
Supports setting specialwordChars with the cfg parameter

### DIFF
--- a/src/languages/StandardSqlFormatter.js
+++ b/src/languages/StandardSqlFormatter.js
@@ -98,7 +98,8 @@ export default class StandardSqlFormatter {
                 closeParens: [")", "END"],
                 indexedPlaceholderTypes: ["?"],
                 namedPlaceholderTypes: ["@", ":"],
-                lineCommentTypes: ["#", "--"]
+                lineCommentTypes: ["#", "--"],
+                specialWordChars: this.cfg.specialWordChars
             });
         }
         return new Formatter(this.cfg, tokenizer).format(query);


### PR DESCRIPTION
In some projects, Freemarker will be used in the SQL file. SQL - Formatter Formatting SQL corrupts Freemarker statements. For example: "<#if stat_type = =" 0 ">" after formatting will become "< #if stat_type = =" 0 “>”(a space is added between the symbols "<" and "#"). Such a statement cannot be executed normally. Whether more configurable items can be opened in the cfg parameter.? Through the cfg parameter, improve the flexibility of the component configuration.