### PR TITLE
Add named argument operators to posgresql

### DIFF
--- a/src/languages/PostgreSqlFormatter.js
+++ b/src/languages/PostgreSqlFormatter.js
@@ -530,6 +530,8 @@ export default class PostgreSqlFormatter extends Formatter {
         '!~*',
         '!~',
         '!!',
+        ':=',
+        '=>',
       ],
     });
   }


### PR DESCRIPTION
Prevent munging of [postgresql named argument operators](https://www.postgresql.org/docs/12/sql-syntax-calling-funcs.html#SQL-SYNTAX-CALLING-FUNCS-NAMED).

Resolves #125.
