### PR TITLE
:bug: fix format error while sql includes false

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -272,6 +272,9 @@ export default class Tokenizer {
   }
 
   getTokenOnFirstMatch({ input, type, regex }) {
+    if (!regex) {
+      return undefined;
+    }
     const matches = input.match(regex);
 
     return matches ? { type, value: matches[1] } : undefined;


### PR DESCRIPTION
while default namedPlaceholderTypes is empty array,  this.IDENT_NAMED_PLACEHOLDER_REGEX is false.
```javascript
    this.IDENT_NAMED_PLACEHOLDER_REGEX = regexFactory.createPlaceholderRegex(
      cfg.namedPlaceholderTypes,
      '[a-zA-Z0-9._$]+'
    );
```
then you got { type: 'palceholder', value: undefined } while formatter sql which includes false.
```javascript
  getPlaceholderTokenWithKey({ input, regex, parseKey }) {
    const token = this.getTokenOnFirstMatch({ input, regex, type: tokenTypes.PLACEHOLDER });
    if (token) {
      token.key = parseKey(token.value);
    }
    return token;
  }
```
and then error occurs while call this function in getIndexedPlaceholderToken.
```
  getIndexedPlaceholderToken(input) {
    return this.getPlaceholderTokenWithKey({
      input,
      regex: this.INDEXED_PLACEHOLDER_REGEX,
      parseKey: (v) => v.slice(1), // v is undefined
    });
  }
```
so it will show the error below in console:
![image](https://user-images.githubusercontent.com/12165373/116104992-7c696100-a6e3-11eb-97fe-2539f42387ba.png)

the merge request resolve this porblem which also refered in #129 