### PR TITLE
Fix tokenizer number regex to include scentific notation

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -20,7 +20,7 @@ export default class Tokenizer {
    */
   constructor(cfg) {
     this.WHITESPACE_REGEX = /^(\s+)/u;
-    this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
+    this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
 
     this.OPERATOR_REGEX = regexFactory.createOperatorRegex([
       '<>',


### PR DESCRIPTION
This PR fixes the number regex for scientific notation with a "+" on `Tokenizer` (e.g. 2E+3)

I don't really know where to create an associated test for the change. If you can give me some pointers, I would gladly create a test for this.

Related issue:
https://github.com/zeroturnaround/sql-formatter/issues/152

Thanks for the work you provide 🙏