### PR TITLE
Add --lines-after-output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sql-formatter -h
 
 ```
 usage: sql-formatter [-h] [-o OUTPUT] [-l {db2,mariadb,mysql,n1ql,plsql,postgresql,redshift,spark,sql,tsql}]
-                     [-i N | -t] [-u] [--lines-between-queries N] [--version] [FILE]
+                     [-i N | -t] [-u] [--lines-between-queries N] [--lines-after-output N] [--version] [FILE]
 
 SQL Formatter
 
@@ -114,6 +114,8 @@ optional arguments:
   -u, --uppercase       Capitalize language keywords
   --lines-between-queries N
                         How many newlines to insert between queries (separated by ";")
+  --lines-after-output N
+                        How many newlines to append after output (defaults to 1)
   --version             show program's version number and exit
 ```
 

--- a/bin/sqlfmt.js
+++ b/bin/sqlfmt.js
@@ -53,6 +53,13 @@ function getArgs() {
     default: 1,
   });
 
+  parser.add_argument('--lines-after-output', {
+    help: 'How many newlines to append after output (defaults to 1)',
+    metavar: 'N',
+    type: 'int',
+    default: 1,
+  });
+
   parser.add_argument('--version', {
     action: 'version',
     version,
@@ -99,5 +106,5 @@ function writeOutput(file, query) {
 const args = getArgs();
 const cfg = configFromArgs(args);
 const query = getInput(args.file);
-const formattedQuery = format(query, cfg).trim() + '\n';
-writeOutput(args.output, formattedQuery);
+const formattedQuery = format(query, cfg).trim();
+writeOutput(args.output, formattedQuery + '\n'.repeat(args.lines_after_output));


### PR DESCRIPTION
In environments like NeoVim, currently appended trailing newline is unnecessary.

Similar to `--lines-between-queries` option, `--lines-after-output` will provide control over trailing newlines.