### PR TITLE
Update PostgreSqlFormatter.js

### DIFF
--- a/src/languages/PostgreSqlFormatter.js
+++ b/src/languages/PostgreSqlFormatter.js
@@ -530,6 +530,7 @@ export default class PostgreSqlFormatter extends Formatter {
         '!~*',
         '!~',
         '!!',
+        '||',
       ],
     });
   }


### PR DESCRIPTION
'||' is one of String concatenation
https://www.postgresql.org/docs/12/functions-string.html