### PR TITLE
CLI: Make stdout output match written file content

### DIFF
--- a/bin/sqlfmt.js
+++ b/bin/sqlfmt.js
@@ -90,7 +90,7 @@ function getInput(file) {
 function writeOutput(file, query) {
   if (!file) {
     // No output file, write to console
-    console.log(query);
+    process.stdout.write(query);
   } else {
     fs.writeFileSync(file, query);
   }


### PR DESCRIPTION
Change sql-formatter CLI to output formatted content without extra newline, to match written file content.
- `console.log` -> `process.stdout.write` to not use redundant `\n`
  - Newline is already appended to the `formattedQuery`, so no need for redundant `\n`
- Can be used to diff against original file content