### PR TITLE
Wrap parentheses based on entire line length

### DIFF
--- a/src/core/Formatter.js
+++ b/src/core/Formatter.js
@@ -84,7 +84,8 @@ export default class Formatter {
         formattedQuery = this.formatWithSpaces(token, formattedQuery);
         this.previousReservedToken = token;
       } else if (token.type === tokenTypes.OPEN_PAREN) {
-        formattedQuery = this.formatOpeningParentheses(token, formattedQuery);
+        const prevLength = formattedQuery.split('\n').pop().length;
+        formattedQuery = this.formatOpeningParentheses(token, formattedQuery, prevLength);
       } else if (token.type === tokenTypes.CLOSE_PAREN) {
         formattedQuery = this.formatClosingParentheses(token, formattedQuery);
       } else if (token.type === tokenTypes.PLACEHOLDER) {
@@ -146,7 +147,7 @@ export default class Formatter {
   }
 
   // Opening parentheses increase the block indent level and start a new line
-  formatOpeningParentheses(token, query) {
+  formatOpeningParentheses(token, query, prevLength) {
     // Take out the preceding space unless there was whitespace there in the original query
     // or another opening parens or line comment
     const preserveWhitespaceFor = {
@@ -162,7 +163,7 @@ export default class Formatter {
     }
     query += this.show(token);
 
-    this.inlineBlock.beginIfPossible(this.tokens, this.index);
+    this.inlineBlock.beginIfPossible(this.tokens, this.index, prevLength);
 
     if (!this.inlineBlock.isActive()) {
       this.indentation.increaseBlockLevel();

--- a/src/core/InlineBlock.js
+++ b/src/core/InlineBlock.js
@@ -20,8 +20,8 @@ export default class InlineBlock {
    * @param  {Object[]} tokens Array of all tokens
    * @param  {Number} index Current token position
    */
-  beginIfPossible(tokens, index) {
-    if (this.level === 0 && this.isInlineBlock(tokens, index)) {
+  beginIfPossible(tokens, index, prevLength) {
+    if (this.level === 0 && this.isInlineBlock(tokens, index, prevLength)) {
       this.level = 1;
     } else if (this.level > 0) {
       this.level++;
@@ -48,13 +48,13 @@ export default class InlineBlock {
 
   // Check if this should be an inline parentheses block
   // Examples are "NOW()", "COUNT(*)", "int(10)", key(`somecolumn`), DECIMAL(7,2)
-  isInlineBlock(tokens, index) {
-    let length = 0;
+  isInlineBlock(tokens, index, prevLength) {
+    let length = prevLength;
     let level = 0;
 
     for (let i = index; i < tokens.length; i++) {
       const token = tokens[i];
-      length += token.value.length;
+      length += token.value.length + token.whitespaceBefore.length;
 
       // Overran max length
       if (length > INLINE_MAX_LENGTH) {


### PR DESCRIPTION
This probably needs further work but I at least wanted to get it started.

## The issue

The formatter currently wraps parentheses if the content is above a certain length(50). It does not however account for the length of the line before the parentheses. This PR passes the current line length to the wrap check so that it can be used as the initial value, wrapping lines earlier. Lines that don't contain parentheses can still become very long.

I also updated the line length check to account for whitespace, but maybe not doing so was per design.

### Input

```sql
CREATE TABLE some_long_table_name (a INT PRIMARY KEY, b TEXT, c INT NOT NULL, d INT NOT NULL);
```

### Output before

```sql
CREATE TABLE some_long_table_name (a INT PRIMARY KEY, b TEXT, c INT NOT NULL, d INT NOT NULL);
```

### Output after

```sql
CREATE TABLE some_long_table_name (
  a INT PRIMARY KEY,
  b TEXT,
  c INT NOT NULL,
  d INT NOT NULL
);
```

## Related issues:

- https://github.com/zeroturnaround/sql-formatter/issues/40
- https://github.com/zeroturnaround/sql-formatter/issues/5