### PR TITLE
Allow no arguments when cli command is piped

### DIFF
--- a/bin/sql-formatter-cli.js
+++ b/bin/sql-formatter-cli.js
@@ -4,6 +4,7 @@
 
 const { format, supportedDialects } = require('../lib/index');
 const fs = require('fs');
+const tty = require('tty');
 const { version } = require('../package.json');
 const { ArgumentParser } = require('argparse');
 
@@ -53,7 +54,7 @@ class PrettierSQLArgs {
   }
 
   readConfig() {
-    if (Object.entries(this.args).every(([k, v]) => k === 'language' || v === undefined)) {
+    if (tty.isatty(0) && Object.entries(this.args).every(([k, v]) => k === 'language' || v === undefined)) {
       this.parser.print_help();
       process.exit(0);
     }


### PR DESCRIPTION
The cli command shows help when no arguments passed.

```
# show help
sql-formatter
```

However, help is also displayed when piped or redirected, as in the following example.

```
# pipe
echo 'select * from tbl where id = 3' | sql-formatter

# redirect
sql-formatter < input.sql
```

I have modified the cli command to not show help when stdin is not tty.
